### PR TITLE
feat: pre-audit pool extension  code

### DIFF
--- a/src/hooks/ClankerHookDynamicFeeV2.sol
+++ b/src/hooks/ClankerHookDynamicFeeV2.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ClankerHookV2} from "./ClankerHookV2.sol";
+
+import {IClankerHookDynamicFee} from "./interfaces/IClankerHookDynamicFee.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {BeforeSwapDelta} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+contract ClankerHookDynamicFeeV2 is ClankerHookV2, IClankerHookDynamicFee {
+    using StateLibrary for IPoolManager;
+
+    uint24 public constant BPS_DENOMINATOR = 10_000;
+    uint24 public constant MIN_BASE_FEE = 2500; // 0.25%;
+    uint256 public constant MAX_DECAY_FILTER_BPS = 30_000;
+    uint256 public constant FEE_CONTROL_DENOMINATOR = 10_000_000_000;
+
+    mapping(PoolId => PoolDynamicFeeVars) internal _poolFeeVars;
+    mapping(PoolId => PoolDynamicConfigVars) internal _poolConfigVars;
+
+    error TickReturned(int24 tick);
+
+    constructor(address _poolManager, address _factory, address _weth)
+        ClankerHookV2(_poolManager, _factory, _weth)
+    {}
+
+    function poolConfigVars(PoolId poolId) external view returns (PoolDynamicConfigVars memory) {
+        return _poolConfigVars[poolId];
+    }
+
+    function poolFeeVars(PoolId poolId) external view returns (PoolDynamicFeeVars memory) {
+        return _poolFeeVars[poolId];
+    }
+
+    function _initializeFeeData(PoolKey memory poolKey, bytes memory feeData) internal override {
+        PoolDynamicConfigVars memory __poolConfigVars = abi.decode(feeData, (PoolDynamicConfigVars));
+
+        if (__poolConfigVars.baseFee < MIN_BASE_FEE) {
+            revert BaseFeeTooLow();
+        }
+
+        if (__poolConfigVars.maxLpFee > MAX_LP_FEE) {
+            revert MaxLpFeeTooHigh();
+        }
+
+        if (__poolConfigVars.baseFee > __poolConfigVars.maxLpFee) {
+            revert BaseFeeGreaterThanMaxLpFee();
+        }
+
+        emit PoolInitialized({
+            poolId: poolKey.toId(),
+            baseFee: __poolConfigVars.baseFee,
+            maxLpFee: __poolConfigVars.maxLpFee,
+            referenceTickFilterPeriod: __poolConfigVars.referenceTickFilterPeriod,
+            feeControlNumerator: __poolConfigVars.feeControlNumerator,
+            decayFilterBps: __poolConfigVars.decayFilterBps,
+            resetPeriod: __poolConfigVars.resetPeriod,
+            resetTickFilter: __poolConfigVars.resetTickFilter
+        });
+
+        _poolConfigVars[poolKey.toId()] = __poolConfigVars;
+    }
+
+    // set the fee based on the tick after the swap
+    function _setFee(PoolKey calldata poolKey, IPoolManager.SwapParams calldata swapParams)
+        internal
+        override
+    {
+        uint256 volAccumulator = _getVolatilityAccumulator(poolKey, swapParams);
+        uint24 lpFee = _getLpFee(volAccumulator, poolKey.toId());
+        _setProtocolFee(lpFee);
+
+        IPoolManager(poolManager).updateDynamicLPFee(poolKey, lpFee);
+    }
+
+    function _getLpFee(uint256 volAccumulator, PoolId poolId) internal returns (uint24 lpFee) {
+        PoolDynamicConfigVars storage _poolConfigVars_ = _poolConfigVars[poolId];
+        uint256 variableFee = uint256(_poolConfigVars_.feeControlNumerator) * (volAccumulator ** 2)
+            / FEE_CONTROL_DENOMINATOR;
+
+        uint256 fee = variableFee + _poolConfigVars_.baseFee;
+        fee = fee > _poolConfigVars_.maxLpFee ? _poolConfigVars_.maxLpFee : fee;
+
+        return uint24(fee);
+    }
+
+    function _getVolatilityAccumulator(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams
+    ) internal returns (uint24 volatilityAccumulator) {
+        PoolId poolId = poolKey.toId();
+        PoolDynamicFeeVars storage poolFVars = _poolFeeVars[poolId];
+        PoolDynamicConfigVars storage poolCVars = _poolConfigVars[poolId];
+        // grab the tick before the swap
+        (, int24 tickBefore,,) = poolManager.getSlot0(poolId);
+
+        // reset the reference tick if the tick filter period has passed
+        if (poolFVars.lastSwapTimestamp + poolCVars.referenceTickFilterPeriod < block.timestamp) {
+            // set the reference tick to the tick before the swap
+            poolFVars.referenceTick = tickBefore;
+
+            // set the reset tick to the tick before the swap and record the reset timestamp
+            poolFVars.resetTick = tickBefore;
+            poolFVars.resetTickTimestamp = block.timestamp;
+
+            // if the reset period has NOT passed but the tick filter period has, trigger
+            // the volatility decay process
+            if (poolFVars.lastSwapTimestamp + poolCVars.resetPeriod > block.timestamp) {
+                // do math in uint256 to avoid overflow
+                uint256 appliedVR = (uint256(poolFVars.prevVA) * uint256(poolCVars.decayFilterBps))
+                    / BPS_DENOMINATOR;
+                if (appliedVR > type(uint24).max) {
+                    poolFVars.appliedVR = type(uint24).max;
+                } else {
+                    poolFVars.appliedVR = uint24(appliedVR);
+                }
+            } else {
+                poolFVars.appliedVR = 0;
+            }
+
+            // set estimated fee for getting simulation closer to actual result
+            uint24 approxLPFee = _getLpFee(poolFVars.appliedVR, poolId);
+            _setProtocolFee(approxLPFee);
+            IPoolManager(poolManager).updateDynamicLPFee(poolKey, approxLPFee);
+        } // if we didn't just reset, check if the reset period has passed
+        else if (poolFVars.resetTickTimestamp + poolCVars.resetPeriod < block.timestamp) {
+            // check if the tick difference is greater than the reset tick filter
+            int24 resetTickDifference = tickBefore > poolFVars.resetTick
+                ? tickBefore - poolFVars.resetTick
+                : poolFVars.resetTick - tickBefore;
+
+            if (resetTickDifference > poolCVars.resetTickFilter) {
+                // the tick difference is large enough, don't kill the reference tick
+                poolFVars.resetTick = tickBefore;
+                poolFVars.resetTickTimestamp = block.timestamp;
+            } else {
+                // the tick difference is not large enough, clear the stored volatility
+                poolFVars.referenceTick = tickBefore;
+                poolFVars.resetTick = tickBefore;
+                poolFVars.resetTickTimestamp = block.timestamp;
+                poolFVars.appliedVR = 0;
+
+                // clear out fee for simulation
+                uint24 approxLPFee = poolCVars.baseFee;
+                _setProtocolFee(approxLPFee);
+                IPoolManager(poolManager).updateDynamicLPFee(poolKey, approxLPFee);
+            }
+        }
+        // update the reference tick timestamp
+        poolFVars.lastSwapTimestamp = block.timestamp;
+
+        // find the tick after via simulation
+        int24 tickAfter = _getTicks(poolKey, swapParams);
+
+        // calculate the tick difference to use in the volatility equation
+        uint24 tickDifference = (poolFVars.referenceTick - tickAfter) > 0
+            ? uint24(poolFVars.referenceTick - tickAfter)
+            : uint24(tickAfter - poolFVars.referenceTick);
+
+        // apply volatility decay
+        // do math in uint256 to avoid overflow
+        uint256 volatilityAccumulator_ = (uint256(tickDifference) + uint256(poolFVars.appliedVR));
+        if (volatilityAccumulator_ > type(uint24).max) {
+            volatilityAccumulator = type(uint24).max;
+        } else {
+            volatilityAccumulator = uint24(volatilityAccumulator_);
+        }
+        poolFVars.prevVA = volatilityAccumulator;
+
+        emit EstimatedTickDifference(tickBefore, tickAfter);
+    }
+
+    function _getTicks(PoolKey calldata poolKey, IPoolManager.SwapParams calldata swapParams)
+        internal
+        returns (int24 tickAfter)
+    {
+        // simulate swap to get the estimated end tick
+        //
+        // note: this is not going to exactly match the result tick,
+        // if we apply a fee change based on this outcome, the resulting
+        // tick of the swap could be shifted
+        try this.simulateSwap(poolKey, swapParams) {
+            revert("simulate swap should fail");
+        } catch (bytes memory reason) {
+            // Decode the selector (first 4 bytes)
+            bytes4 selector = bytes4(reason);
+
+            if (selector != TickReturned.selector) {
+                revert("returned selector should be TickReturned");
+            }
+
+            // Decode the uint24 value (assuming it's at the end)
+            assembly {
+                // If we're looking at the last 32 bytes, we need to position our pointer
+                // reason + 32 (to skip length) + reason.length - 32 (to get to the last 32 bytes)
+                let lastWordPtr := add(add(reason, 32), sub(mload(reason), 32))
+
+                // For uint24, we only need the last 3 bytes of the last word
+                // This assumes the uint24 is right-aligned in the last word
+                let lastWord := mload(lastWordPtr)
+
+                // Mask to get only the last 3 bytes (24 bits)
+                tickAfter := and(lastWord, 0xFFFFFF)
+            }
+        }
+    }
+
+    function simulateSwap(PoolKey calldata poolKey, IPoolManager.SwapParams memory swapParams)
+        external
+    {
+        if (msg.sender != address(this)) {
+            revert("simulateSwap can only be called by the hook");
+        }
+
+        // apply the protocol fee adjustments to have simulation closer to actual result
+        bool token0IsClanker = clankerIsToken0[poolKey.toId()];
+        bool swappingForClanker = swapParams.zeroForOne != token0IsClanker;
+        bool isExactInput = swapParams.amountSpecified < 0;
+        if (isExactInput && swappingForClanker) {
+            uint128 scaledProtocolFee = uint128(protocolFee) * 1e18 / (1_000_000 + protocolFee);
+            int128 fee = int128(swapParams.amountSpecified * -int128(scaledProtocolFee) / 1e18);
+            swapParams.amountSpecified = swapParams.amountSpecified + fee;
+        }
+        if (!isExactInput && !swappingForClanker) {
+            uint128 scaledProtocolFee = uint128(protocolFee) * 1e18 / (1_000_000 - protocolFee);
+            int128 fee = int128(swapParams.amountSpecified * int128(scaledProtocolFee) / 1e18);
+            swapParams.amountSpecified = swapParams.amountSpecified + fee;
+        }
+
+        // run the swap
+        poolManager.swap(poolKey, swapParams, abi.encode());
+
+        // get the tick after the swap
+        (, int24 tickAfter,,) = poolManager.getSlot0(poolKey.toId());
+
+        // return the tick post-swap
+        revert TickReturned(tickAfter);
+    }
+}

--- a/src/hooks/ClankerHookStaticFeeV2.sol
+++ b/src/hooks/ClankerHookStaticFeeV2.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ClankerHookV2} from "./ClankerHookV2.sol";
+import {IClankerHookStaticFee} from "./interfaces/IClankerHookStaticFee.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+contract ClankerHookStaticFeeV2 is ClankerHookV2, IClankerHookStaticFee {
+    mapping(PoolId => uint24) public clankerFee;
+    mapping(PoolId => uint24) public pairedFee;
+
+    constructor(address _poolManager, address _factory, address _weth)
+        ClankerHookV2(_poolManager, _factory, _weth)
+    {}
+
+    function _initializeFeeData(PoolKey memory poolKey, bytes memory feeData) internal override {
+        PoolStaticConfigVars memory _poolConfigVars = abi.decode(feeData, (PoolStaticConfigVars));
+
+        if (_poolConfigVars.clankerFee > MAX_LP_FEE) {
+            revert ClankerFeeTooHigh();
+        }
+
+        if (_poolConfigVars.pairedFee > MAX_LP_FEE) {
+            revert PairedFeeTooHigh();
+        }
+
+        clankerFee[poolKey.toId()] = _poolConfigVars.clankerFee;
+        pairedFee[poolKey.toId()] = _poolConfigVars.pairedFee;
+
+        emit PoolInitialized(poolKey.toId(), _poolConfigVars.clankerFee, _poolConfigVars.pairedFee);
+    }
+
+    // set the LP fee according to the clanker/paired fee configuration
+    function _setFee(PoolKey calldata poolKey, IPoolManager.SwapParams calldata swapParams)
+        internal
+        override
+    {
+        uint24 fee = swapParams.zeroForOne != clankerIsToken0[poolKey.toId()]
+            ? pairedFee[poolKey.toId()]
+            : clankerFee[poolKey.toId()];
+
+        _setProtocolFee(fee);
+        IPoolManager(poolManager).updateDynamicLPFee(poolKey, fee);
+    }
+}

--- a/src/hooks/ClankerHookV2.sol
+++ b/src/hooks/ClankerHookV2.sol
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ClankerToken} from "../ClankerToken.sol";
+
+import {IClanker} from "../interfaces/IClanker.sol";
+
+import {IClankerLpLocker} from "../interfaces/IClankerLpLocker.sol";
+import {IClankerMevModule} from "../interfaces/IClankerMevModule.sol";
+import {IPermit2} from "@uniswap/permit2/src/interfaces/IPermit2.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {Hooks, IHooks} from "@uniswap/v4-core/src/libraries/Hooks.sol";
+import {IPositionManager} from "@uniswap/v4-periphery/src/interfaces/IPositionManager.sol";
+
+import {IClankerHookV2PoolExtension} from "./interfaces/IClankerHookV2PoolExtension.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IClankerHook} from "../interfaces/IClankerHook.sol";
+import {IClankerHookV2} from "./interfaces/IClankerHookV2.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IUnlockCallback} from "@uniswap/v4-core/src/interfaces/callback/IUnlockCallback.sol";
+import {LPFeeLibrary} from "@uniswap/v4-core/src/libraries/LPFeeLibrary.sol";
+
+import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+import {BalanceDeltaLibrary} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BalanceDelta, add, sub, toBalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, toBeforeSwapDelta} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {
+    BeforeSwapDelta, BeforeSwapDeltaLibrary
+} from "@uniswap/v4-core/src/types/BeforeSwapDelta.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {Actions} from "@uniswap/v4-periphery/src/libraries/Actions.sol";
+import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
+import {BaseHook} from "@uniswap/v4-periphery/src/utils/BaseHook.sol";
+import {console} from "forge-std/console.sol";
+
+abstract contract ClankerHookV2 is BaseHook, IClankerHookV2 {
+    using TickMath for int24;
+    using BeforeSwapDeltaLibrary for BeforeSwapDelta;
+    using StateLibrary for *;
+
+    uint24 public constant MAX_LP_FEE = 300_000; // LP fee capped at 30%
+    uint256 public constant PROTOCOL_FEE_NUMERATOR = 200_000; // 20% of the imposed LP fee
+    int128 public constant FEE_DENOMINATOR = 1_000_000; // Uniswap 100% fee
+
+    uint24 public protocolFee;
+
+    address public immutable factory;
+    address public immutable weth;
+
+    mapping(PoolId => bool) public clankerIsToken0;
+    mapping(PoolId => address) public locker;
+
+    // mev module pool variables
+    uint256 public constant MAX_MEV_MODULE_DELAY = 20 minutes;
+    mapping(PoolId => address) public mevModule;
+    mapping(PoolId => bool) public mevModuleEnabled;
+    mapping(PoolId => uint256) public poolCreationTimestamp;
+    mapping(PoolId => address) public poolExtension;
+
+    modifier onlyFactory() {
+        if (msg.sender != factory) {
+            revert OnlyFactory();
+        }
+        _;
+    }
+
+    constructor(address _poolManager, address _factory, address _weth)
+        BaseHook(IPoolManager(_poolManager))
+    {
+        factory = _factory;
+        weth = _weth;
+    }
+
+    // function to for inheriting hooks to set fees in _beforeSwap hook
+    function _setFee(PoolKey calldata poolKey, IPoolManager.SwapParams calldata swapParams)
+        internal
+        virtual
+    {
+        return;
+    }
+
+    // function to set the protocol fee to 20% of the lp fee
+    function _setProtocolFee(uint24 lpFee) internal {
+        protocolFee = uint24(uint256(lpFee) * PROTOCOL_FEE_NUMERATOR / uint128(FEE_DENOMINATOR));
+    }
+
+    // function to for inheriting hooks to set process data in during initialization flow
+    function _initializeFeeData(PoolKey memory poolKey, bytes memory feeData) internal virtual {
+        return;
+    }
+
+    function _initializePoolExtensionData(
+        PoolKey memory poolKey,
+        address _poolExtension,
+        bytes memory poolExtensionData
+    ) internal virtual {
+        if (_poolExtension != address(0)) {
+            IClankerHookV2PoolExtension(_poolExtension).initializePreLockerSetup(
+                poolKey, clankerIsToken0[poolKey.toId()], poolExtensionData
+            );
+            poolExtension[poolKey.toId()] = _poolExtension;
+        }
+        return;
+    }
+
+    // function for the factory to initialize a pool
+    function initializePool(
+        address clanker,
+        address pairedToken,
+        int24 tickIfToken0IsClanker,
+        int24 tickSpacing,
+        address _locker,
+        address _mevModule,
+        bytes calldata poolData
+    ) public onlyFactory returns (PoolKey memory) {
+        // initialize the pool
+        PoolKey memory poolKey =
+            _initializePool(clanker, pairedToken, tickIfToken0IsClanker, tickSpacing, poolData);
+
+        // set the locker config
+        locker[poolKey.toId()] = _locker;
+
+        // set the mev module
+        mevModule[poolKey.toId()] = _mevModule;
+
+        emit PoolCreatedFactory({
+            pairedToken: pairedToken,
+            clanker: clanker,
+            poolId: poolKey.toId(),
+            tickIfToken0IsClanker: tickIfToken0IsClanker,
+            tickSpacing: tickSpacing,
+            locker: _locker,
+            mevModule: _mevModule
+        });
+
+        return poolKey;
+    }
+
+    // function to let anyone initialize a pool
+    //
+    // this is allow tokens not created by the factory to be used with this hook
+    //
+    // note: these pools do not have lp locker auto-claim or mev module functionality
+    function initializePoolOpen(
+        address clanker,
+        address pairedToken,
+        int24 tickIfToken0IsClanker,
+        int24 tickSpacing,
+        bytes calldata poolData
+    ) public returns (PoolKey memory) {
+        // if able, we prefer that weth is not the clanker as our hook fee will only
+        // collect fees on the paired token
+        if (clanker == weth) {
+            revert WethCannotBeClanker();
+        }
+
+        PoolKey memory poolKey =
+            _initializePool(clanker, pairedToken, tickIfToken0IsClanker, tickSpacing, poolData);
+
+        emit PoolCreatedOpen(
+            pairedToken, clanker, poolKey.toId(), tickIfToken0IsClanker, tickSpacing
+        );
+
+        return poolKey;
+    }
+
+    // common actions for initializing a pool
+    function _initializePool(
+        address clanker,
+        address pairedToken,
+        int24 tickIfToken0IsClanker,
+        int24 tickSpacing,
+        bytes calldata poolData
+    ) internal virtual returns (PoolKey memory) {
+        // ensure that the pool is not an ETH pool
+        if (pairedToken == address(0) || clanker == address(0)) {
+            revert ETHPoolNotAllowed();
+        }
+
+        // determine if clanker is token0
+        bool token0IsClanker = clanker < pairedToken;
+
+        // create the pool key
+        PoolKey memory _poolKey = PoolKey({
+            currency0: Currency.wrap(token0IsClanker ? clanker : pairedToken),
+            currency1: Currency.wrap(token0IsClanker ? pairedToken : clanker),
+            fee: LPFeeLibrary.DYNAMIC_FEE_FLAG,
+            tickSpacing: tickSpacing,
+            hooks: IHooks(address(this))
+        });
+
+        // Set the storage helpers
+        clankerIsToken0[_poolKey.toId()] = token0IsClanker;
+
+        // initialize the pool
+        int24 startingTick = token0IsClanker ? tickIfToken0IsClanker : -tickIfToken0IsClanker;
+        uint160 initialPrice = startingTick.getSqrtPriceAtTick();
+        poolManager.initialize(_poolKey, initialPrice);
+
+        // set the pool creation timestamp
+        poolCreationTimestamp[_poolKey.toId()] = block.timestamp;
+
+        // decode the pool data into user extension data and pool data
+        PoolInitializationData memory poolInitializationData =
+            abi.decode(poolData, (PoolInitializationData));
+
+        // initialize fee data
+        _initializeFeeData(_poolKey, poolInitializationData.feeData);
+
+        // initialize pool extension data
+        _initializePoolExtensionData(
+            _poolKey, poolInitializationData.extension, poolInitializationData.extensionData
+        );
+
+        return _poolKey;
+    }
+
+    // enable the mev module once the pool's deployment is complete
+    //
+    // note: this is done separate from the initializePool to allow for
+    // extensions to take pool actions
+    function initializeMevModule(PoolKey calldata poolKey, bytes calldata mevModuleData)
+        external
+        onlyFactory
+    {
+        // initialize the mev module
+        IClankerMevModule(mevModule[poolKey.toId()]).initialize(poolKey, mevModuleData);
+
+        // give pool extension, if it exists, chance to check other configured settings
+        if (poolExtension[poolKey.toId()] != address(0)) {
+            IClankerHookV2PoolExtension(poolExtension[poolKey.toId()]).initializePostLockerSetup(
+                poolKey, locker[poolKey.toId()], clankerIsToken0[poolKey.toId()]
+            );
+        }
+
+        // enable the mev module
+        mevModuleEnabled[poolKey.toId()] = true;
+    }
+
+    // returns true if the mev module is enabled and not expired
+    function mevModuleOperational(PoolId poolId) public view returns (bool) {
+        return mevModuleEnabled[poolId]
+            && block.timestamp < poolCreationTimestamp[poolId] + MAX_MEV_MODULE_DELAY;
+    }
+
+    // function to allow the mev module to change the fee for a swap
+    function mevModuleSetFee(PoolKey calldata poolKey, uint24 fee) external {
+        // only the assigned mev module for a poolkey can update the fee
+        if (mevModule[poolKey.toId()] != msg.sender) {
+            revert Unauthorized();
+        }
+
+        // skip if the mev module is not operational
+        if (!mevModuleOperational(poolKey.toId())) {
+            return;
+        }
+
+        // check to see if the fee is higher than the currently set LP fee,
+        // we only want to update if it is higher than the pool's normal fee behavior
+        (,,, uint24 currentLpFee) = StateLibrary.getSlot0(poolManager, poolKey.toId());
+        if (fee <= currentLpFee) {
+            return;
+        }
+
+        // update the fee for the swap
+        IPoolManager(poolManager).updateDynamicLPFee(poolKey, fee);
+        _setProtocolFee(fee);
+
+        emit MevModuleSetFee(poolKey.toId(), fee);
+    }
+
+    function _runMevModule(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        bytes calldata swapData
+    ) internal {
+        if (mevModuleOperational(poolKey.toId())) {
+            // decode the swap data for the pool extension
+            PoolSwapData memory poolSwapData;
+            if (swapData.length > 0) {
+                poolSwapData = abi.decode(swapData, (PoolSwapData));
+            } else {
+                poolSwapData = PoolSwapData({
+                    mevModuleSwapData: new bytes(0),
+                    poolExtensionSwapData: new bytes(0)
+                });
+            }
+
+            // if the mev module is enabled  call it
+            bool disableMevModule = IClankerMevModule(mevModule[poolKey.toId()]).beforeSwap(
+                poolKey, swapParams, clankerIsToken0[poolKey.toId()], poolSwapData.mevModuleSwapData
+            );
+
+            // disable the mevModule if the module requests it
+            if (disableMevModule) {
+                mevModuleEnabled[poolKey.toId()] = false;
+                emit MevModuleDisabled(poolKey.toId());
+            }
+        }
+    }
+
+    function _runPoolExtension(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        BalanceDelta delta,
+        bytes calldata swapData
+    ) internal {
+        console.log("poolExtension");
+        console.log(poolExtension[poolKey.toId()]);
+
+        if (poolExtension[poolKey.toId()] != address(0)) {
+            // decode the swap data for the mev module
+            PoolSwapData memory poolSwapData;
+            if (swapData.length > 0) {
+                poolSwapData = abi.decode(swapData, (PoolSwapData));
+            } else {
+                poolSwapData = PoolSwapData({
+                    mevModuleSwapData: new bytes(0),
+                    poolExtensionSwapData: new bytes(0)
+                });
+            }
+
+            console.log("poolExtensionSwapData");
+
+            try this._runPoolExtensionHelper(
+                poolKey, swapParams, delta, poolSwapData.poolExtensionSwapData
+            ) {
+                emit PoolExtensionSuccess(poolKey.toId());
+            } catch {
+                emit PoolExtensionFailed(poolKey.toId(), swapParams);
+            }
+        }
+    }
+
+    function _runPoolExtensionHelper(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        BalanceDelta delta,
+        bytes calldata swapData
+    ) external {
+        if (msg.sender != address(this)) {
+            revert OnlyThis();
+        }
+
+        IClankerHookV2PoolExtension(poolExtension[poolKey.toId()]).afterSwap(
+            poolKey, swapParams, delta, clankerIsToken0[poolKey.toId()], swapData
+        );
+    }
+
+    function _lpLockerFeeClaim(PoolKey calldata poolKey) internal {
+        // if this wasn't initialized to claim fees, skip the claim
+        if (locker[poolKey.toId()] == address(0)) {
+            return;
+        }
+
+        // determine the token
+        address token = clankerIsToken0[poolKey.toId()]
+            ? Currency.unwrap(poolKey.currency0)
+            : Currency.unwrap(poolKey.currency1);
+
+        // trigger the fee claim
+        IClankerLpLocker(locker[poolKey.toId()]).collectRewardsWithoutUnlock(token);
+    }
+
+    function _hookFeeClaim(PoolKey calldata poolKey) internal {
+        // determine the fee token
+        Currency feeCurrency =
+            clankerIsToken0[poolKey.toId()] ? poolKey.currency1 : poolKey.currency0;
+
+        // get the fees stored from the previous swap in the pool manager
+        uint256 fee = poolManager.balanceOf(address(this), feeCurrency.toId());
+
+        if (fee == 0) {
+            return;
+        }
+
+        // burn the fee
+        poolManager.burn(address(this), feeCurrency.toId(), fee);
+
+        // take the fee
+        poolManager.take(feeCurrency, factory, fee);
+
+        emit ClaimProtocolFees(Currency.unwrap(feeCurrency), fee);
+    }
+
+    function _beforeSwap(
+        address,
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        bytes calldata swapData
+    ) internal virtual override returns (bytes4, BeforeSwapDelta delta, uint24) {
+        // set the fee for this swap
+        _setFee(poolKey, swapParams);
+
+        // trigger hook fee claim
+        _hookFeeClaim(poolKey);
+
+        // trigger the LP locker fee claim
+        _lpLockerFeeClaim(poolKey);
+
+        // run the mev module, can update the fee for the swap
+        _runMevModule(poolKey, swapParams, swapData);
+
+        // variables to determine how to collect protocol fee
+        bool token0IsClanker = clankerIsToken0[poolKey.toId()];
+        bool swappingForClanker = swapParams.zeroForOne != token0IsClanker;
+        bool isExactInput = swapParams.amountSpecified < 0;
+
+        // case: specified amount paired in, unspecified amount clanker out
+        // want to: keep amountIn the same, take fee on amountIn
+        // how: we modulate the specified amount being swapped DOWN, and
+        // transfer the difference into the hook's account before making the swap
+        if (isExactInput && swappingForClanker) {
+            // since we're taking the protocol fee before the LP swap, we want to
+            // take a slightly smaller amount to keep the taken LP/protocol fee at the 20% ratio,
+            // this also helps us match the ExactOutput swappingForClanker scenario
+            uint128 scaledProtocolFee = uint128(protocolFee) * 1e18 / (1_000_000 + protocolFee);
+            int128 fee = int128(swapParams.amountSpecified * -int128(scaledProtocolFee) / 1e18);
+
+            delta = toBeforeSwapDelta(fee, 0);
+            poolManager.mint(
+                address(this),
+                token0IsClanker ? poolKey.currency1.toId() : poolKey.currency0.toId(),
+                uint256(int256(fee))
+            );
+        }
+
+        // case: specified amount paired out, unspecified amount clanker in
+        // want to: increase amountOut by fee and take it
+        // how: we modulate the specified amount out UP, and transfer it
+        // into the hook's account
+        if (!isExactInput && !swappingForClanker) {
+            // we increase the protocol fee here because we want to better match
+            // the ExactOutput !swappingForClanker scenario
+            uint128 scaledProtocolFee = uint128(protocolFee) * 1e18 / (1_000_000 - protocolFee);
+            int128 fee = int128(swapParams.amountSpecified * int128(scaledProtocolFee) / 1e18);
+            delta = toBeforeSwapDelta(fee, 0);
+
+            poolManager.mint(
+                address(this),
+                token0IsClanker ? poolKey.currency1.toId() : poolKey.currency0.toId(),
+                uint256(int256(fee))
+            );
+        }
+
+        return (BaseHook.beforeSwap.selector, delta, 0);
+    }
+
+    function _afterSwap(
+        address,
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        BalanceDelta delta,
+        bytes calldata swapData
+    ) internal override returns (bytes4, int128 unspecifiedDelta) {
+        // variables to determine how to collect protocol fee
+        bool token0IsClanker = clankerIsToken0[poolKey.toId()];
+        bool swappingForClanker = swapParams.zeroForOne != token0IsClanker;
+        bool isExactInput = swapParams.amountSpecified < 0;
+
+        // case: specified amount clanker in, unspecified amount paired out
+        // want to: take fee on amount out
+        // how: the change in unspecified delta is debited to the swaps account post swap,
+        // in this case the amount out given to the swapper is decreased
+        if (isExactInput && !swappingForClanker) {
+            // grab non-clanker amount out
+            int128 amountOut = token0IsClanker ? delta.amount1() : delta.amount0();
+            // take fee from it
+            unspecifiedDelta = amountOut * int24(protocolFee) / FEE_DENOMINATOR;
+            poolManager.mint(
+                address(this),
+                token0IsClanker ? poolKey.currency1.toId() : poolKey.currency0.toId(),
+                uint256(int256(unspecifiedDelta))
+            );
+
+            // subtract the protocol fee from the positive delta to account for the protocol fee
+            // (positive for the swapper means amount owed to the swapper)
+            if (delta.amount0() > 0) {
+                delta = sub(delta, toBalanceDelta(unspecifiedDelta, 0));
+            } else {
+                delta = sub(delta, toBalanceDelta(0, unspecifiedDelta));
+            }
+        }
+
+        // case: specified amount clanker out, unspecified amount paired in
+        // want to: take fee on amount in
+        // how: the change in unspecified delta is debited to the swapper's account post swap,
+        // in this case the amount taken from the swapper's account is increased
+        if (!isExactInput && swappingForClanker) {
+            // grab non-clanker amount in
+            int128 amountIn = token0IsClanker ? delta.amount1() : delta.amount0();
+            // take fee from amount int
+            unspecifiedDelta = amountIn * -int24(protocolFee) / FEE_DENOMINATOR;
+            poolManager.mint(
+                address(this),
+                token0IsClanker ? poolKey.currency1.toId() : poolKey.currency0.toId(),
+                uint256(int256(unspecifiedDelta))
+            );
+
+            // subtract the protocol fee from the negative delta to account for the protocol fee
+            // (negative for the swapper means amount owed to the pool)
+            if (delta.amount0() < 0) {
+                delta = sub(delta, toBalanceDelta(unspecifiedDelta, 0));
+            } else {
+                delta = sub(delta, toBalanceDelta(0, unspecifiedDelta));
+            }
+        }
+
+        // modify deltas to account for when the protocol fee is taken in beforeSwap,
+        // the actual user delta is the amount specified in the swap params
+        if (isExactInput && swappingForClanker) {
+            // need to modify the paired delta to be the amount specified in the swap params
+            if (clankerIsToken0[poolKey.toId()]) {
+                delta = toBalanceDelta(delta.amount0(), int128(swapParams.amountSpecified));
+            } else {
+                delta = toBalanceDelta(int128(swapParams.amountSpecified), delta.amount1());
+            }
+        } else if (!isExactInput && !swappingForClanker) {
+            // TODO: test is if this is correct ...
+            // need to modify the clanker delta to be the amount specified in the swap params
+            if (clankerIsToken0[poolKey.toId()]) {
+                delta = toBalanceDelta(int128(swapParams.amountSpecified), delta.amount1());
+            } else {
+                delta = toBalanceDelta(delta.amount0(), int128(swapParams.amountSpecified));
+            }
+        }
+
+        // run the pool extension
+        _runPoolExtension(poolKey, swapParams, delta, swapData);
+
+        return (BaseHook.afterSwap.selector, unspecifiedDelta);
+    }
+
+    // prevent initializations that don't start via our initializePool functions
+    function _beforeInitialize(address, PoolKey calldata, uint160)
+        internal
+        virtual
+        override
+        returns (bytes4)
+    {
+        revert UnsupportedInitializePath();
+    }
+
+    // prevent liquidity adds during mev module operation
+    function _beforeAddLiquidity(
+        address,
+        PoolKey calldata poolKey,
+        IPoolManager.ModifyLiquidityParams calldata,
+        bytes calldata
+    ) internal virtual override returns (bytes4) {
+        if (mevModuleOperational(poolKey.toId())) {
+            revert MevModuleEnabled();
+        }
+
+        return BaseHook.beforeAddLiquidity.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IClankerHook).interfaceId
+            || interfaceId == type(IClankerHookV2).interfaceId;
+    }
+
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: true,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: true,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: true,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+}

--- a/src/hooks/interfaces/IClankerHookV2.sol
+++ b/src/hooks/interfaces/IClankerHookV2.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+import {IClankerHook} from "../../interfaces/IClankerHook.sol";
+
+interface IClankerHookV2 is IClankerHook {
+    error OnlyThis();
+    error MevModuleNotOperational();
+    error Unauthorized();
+
+    event PoolExtensionSuccess(PoolId poolId);
+    event PoolExtensionFailed(PoolId poolId, IPoolManager.SwapParams swapParams);
+    event MevModuleSetFee(PoolId poolId, uint24 fee);
+
+    struct PoolInitializationData {
+        address extension;
+        bytes extensionData;
+        bytes feeData;
+    }
+
+    struct PoolSwapData {
+        bytes mevModuleSwapData;
+        bytes poolExtensionSwapData;
+    }
+
+    function mevModuleSetFee(PoolKey calldata poolKey, uint24 fee) external;
+
+    function mevModuleEnabled(PoolId poolId) external view returns (bool);
+    function poolCreationTimestamp(PoolId poolId) external view returns (uint256);
+    function MAX_MEV_MODULE_DELAY() external view returns (uint256);
+    function MAX_LP_FEE() external view returns (uint24);
+}

--- a/src/hooks/interfaces/IClankerHookV2PoolExtension.sol
+++ b/src/hooks/interfaces/IClankerHookV2PoolExtension.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClanker} from "../../interfaces/IClanker.sol";
+
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+interface IClankerHookV2PoolExtension {
+    error OnlyHook();
+
+    // initialize the user extension, called once by the hook per pool during pool initialization flow
+    function initializePreLockerSetup(
+        PoolKey calldata poolKey,
+        bool clankerIsToken0,
+        bytes calldata poolExtensionInitData
+    ) external;
+
+    // initialize the user extension, called once by the hook per pool after the locker is setup,
+    // during the mev module initialization flow
+    function initializePostLockerSetup(
+        PoolKey calldata poolKey,
+        address locker,
+        bool clankerIsToken0
+    ) external;
+
+    // after a swap, call the user extension to perform any post-swap actions
+    function afterSwap(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        BalanceDelta delta,
+        bool clankerIsToken0,
+        bytes calldata poolExtensionSwapData
+    ) external;
+
+    // implements the IClankerHookV2PoolExtension interface
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool);
+}

--- a/src/hooks/pool-extension-examples/DataUsageExample.sol
+++ b/src/hooks/pool-extension-examples/DataUsageExample.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClanker} from "../../interfaces/IClanker.sol";
+import {IClankerFeeLocker} from "../../interfaces/IClankerFeeLocker.sol";
+import {IClankerLpLocker} from "../../interfaces/IClankerLpLocker.sol";
+import {IClankerLpLockerFeeConversion} from
+    "../../lp-lockers/interfaces/IClankerLpLockerFeeConversion.sol";
+import {IClankerHookV2} from "../interfaces/IClankerHookV2.sol";
+
+import {IClankerHookV2PoolExtension} from "../interfaces/IClankerHookV2PoolExtension.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+
+import {console} from "forge-std/console.sol";
+
+// example pool extension that accesses passed in data in the setup and swap phases
+contract DataUsageExample is IClankerHookV2PoolExtension {
+    error InvalidFoo();
+
+    uint256 constant REQUIRED_FOO = 42;
+    mapping(
+        address user => mapping(PoolId poolId => mapping(address tokenSpent => uint128 amountSpent))
+    ) public amountSpent;
+
+    struct PoolInitializationData {
+        uint256 foo;
+    }
+
+    struct PoolSwapData {
+        address user;
+    }
+
+    // initialized pool keys
+    mapping(PoolId => bool) public initializedPoolKeys;
+
+    modifier onlyHook(PoolKey calldata poolKey) {
+        if (msg.sender != address(poolKey.hooks)) {
+            revert OnlyHook();
+        }
+        _;
+    }
+
+    function initializePreLockerSetup(
+        PoolKey calldata poolKey,
+        bool clankerIsToken0,
+        bytes calldata poolExtensionData
+    ) external onlyHook(poolKey) {
+        // check that the foo is the required foo
+        //
+        // could revent on other conditions too, e.g. the passed in data is a signature
+        // from a particular address over the pool key and the tx.origin
+        if (abi.decode(poolExtensionData, (PoolInitializationData)).foo != REQUIRED_FOO) {
+            revert InvalidFoo();
+        }
+
+        // set the pool key as initialized
+        initializedPoolKeys[poolKey.toId()] = true;
+    }
+
+    function initializePostLockerSetup(PoolKey calldata poolKey, address lpLocker, bool)
+        external
+        onlyHook(poolKey)
+    {}
+
+    // called after a swap has completed
+    function afterSwap(
+        PoolKey calldata poolKey,
+        IPoolManager.SwapParams calldata swapParams,
+        BalanceDelta delta,
+        bool clankerIsToken0,
+        bytes calldata swapData
+    ) external onlyHook(poolKey) {
+        // attempt to decode the swap data if present
+        //
+        // note: if the swap data is in the wrong shape, this will revert but the hook will
+        // handle it gracefully and continue the swap
+        PoolSwapData memory poolSwapData = abi.decode(swapData, (PoolSwapData));
+
+        if (poolSwapData.user == address(0)) {
+            return;
+        }
+
+        // record the amount of token spent by the user
+        // note for the delta: the amount owed to the caller (positive) or owed to the pool (negative)
+        if (delta.amount1() < 0) {
+            console.log("---");
+            console.log("delta1", delta.amount1());
+            console.log("poolKey.currency1 unwrapped", Currency.unwrap(poolKey.currency1));
+            console.log("amount spent", swapParams.amountSpecified);
+            amountSpent[poolSwapData.user][poolKey.toId()][Currency.unwrap(poolKey.currency1)] +=
+                uint128(-delta.amount1());
+        } else {
+            console.log("---");
+            console.log("delta0", delta.amount0());
+            console.log("poolKey.currency0 unwrapped", Currency.unwrap(poolKey.currency0));
+            console.log("amount spent", swapParams.amountSpecified);
+            amountSpent[poolSwapData.user][poolKey.toId()][Currency.unwrap(poolKey.currency0)] +=
+                uint128(-delta.amount0());
+        }
+    }
+
+    // implements the IClankerHookV2PoolExtension interface
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IClankerHookV2PoolExtension).interfaceId;
+    }
+}

--- a/src/hooks/pool-extension-examples/UniV3SwapBack.sol
+++ b/src/hooks/pool-extension-examples/UniV3SwapBack.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IClanker} from "../../interfaces/IClanker.sol";
+import {IClankerFeeLocker} from "../../interfaces/IClankerFeeLocker.sol";
+import {IClankerLpLocker} from "../../interfaces/IClankerLpLocker.sol";
+import {IClankerLpLockerFeeConversion} from
+    "../../lp-lockers/interfaces/IClankerLpLockerFeeConversion.sol";
+import {IClankerHookV2} from "../interfaces/IClankerHookV2.sol";
+
+import {IClankerHookV2PoolExtension} from "../interfaces/IClankerHookV2PoolExtension.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
+
+import {ISwapRouterV3} from "../../utils/ISwapRouterv3.sol";
+import {BalanceDelta} from "@uniswap/v4-core/src/types/BalanceDelta.sol";
+
+import {PoolId} from "@uniswap/v4-core/src/types/PoolId.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Currency} from "@uniswap/v4-core/src/types/Currency.sol";
+
+import {console} from "forge-std/console.sol";
+
+// example pool extension that takes fees generated for a fee recipient and
+// swaps them for a different token
+contract UniV3SwapBuyBack is IClankerHookV2PoolExtension, Ownable {
+    error LpLockerNotSet();
+    error CannotWithdrawInputToken();
+    error ClankerNotPairedWithTargetInputToken();
+    error InvalidFirstFeeRecipient();
+    error InvalidFirstFeeAdmin();
+    error InvalidFirstFeePreference();
+    error OnlyApprovedHooks();
+
+    event BuyBackRecipientSet(address previousBuyBackRecipient, address newBuyBackRecipient);
+    event HookApproved(address hook);
+    event SwappedBack(address inputToken, address outputToken, uint256 amountIn, uint256 amountOut);
+
+    // addresses of the fee locker and uni v3 router
+    IClanker clankerFactory;
+    IClankerFeeLocker feeLocker;
+    mapping(address hook => bool approved) public approvedHooks; // addresses of the approved hooks
+    ISwapRouterV3 uniV3Router;
+
+    // univ3 pool to swap fee token for
+    address public uniV3InputToken;
+    address public uniV3OutputToken;
+    uint24 public uniV3Fee;
+
+    // address to receive the bought back fees
+    address public buyBackRecipient;
+
+    constructor(
+        address _owner,
+        address _clankerFactory,
+        address _feeLocker,
+        address _uniV3Router,
+        address _uniV3InputToken,
+        address _uniV3OutputToken,
+        uint24 _uniV3Fee,
+        address _buyBackRecipient,
+        address[] memory _approvedHooks
+    ) Ownable(_owner) {
+        clankerFactory = IClanker(_clankerFactory);
+        feeLocker = IClankerFeeLocker(_feeLocker);
+        uniV3Router = ISwapRouterV3(_uniV3Router);
+        uniV3InputToken = _uniV3InputToken;
+        uniV3OutputToken = _uniV3OutputToken;
+        uniV3Fee = _uniV3Fee;
+        buyBackRecipient = _buyBackRecipient;
+        for (uint256 i = 0; i < _approvedHooks.length; i++) {
+            approvedHooks[_approvedHooks[i]] = true;
+        }
+    }
+
+    modifier onlyApprovedHooks() {
+        if (!approvedHooks[msg.sender]) {
+            revert OnlyApprovedHooks();
+        }
+        _;
+    }
+
+    // change the address that receives the bought back fees
+    function setBuyBackRecipient(address _buyBackRecipient) external onlyOwner {
+        address previousBuyBackRecipient = buyBackRecipient;
+        buyBackRecipient = _buyBackRecipient;
+        emit BuyBackRecipientSet(previousBuyBackRecipient, buyBackRecipient);
+    }
+
+    function approveHook(address _hook) external onlyOwner {
+        approvedHooks[_hook] = true;
+        emit HookApproved(_hook);
+    }
+
+    // initialize the user extension with passed in data, called once per pool
+    function initializePreLockerSetup(PoolKey calldata, bool, bytes calldata)
+        external
+        onlyApprovedHooks
+    {}
+
+    function initializePostLockerSetup(
+        PoolKey calldata poolKey,
+        address lpLocker,
+        bool clankerIsToken0
+    ) external onlyApprovedHooks {
+        // grab the deployed clanker and paired token
+        address clanker = clankerIsToken0
+            ? Currency.unwrap(poolKey.currency0)
+            : Currency.unwrap(poolKey.currency1);
+        address pairedToken = clankerIsToken0
+            ? Currency.unwrap(poolKey.currency1)
+            : Currency.unwrap(poolKey.currency0);
+
+        // check that the token's paired token is the input token
+        if (pairedToken != uniV3InputToken) {
+            revert ClankerNotPairedWithTargetInputToken();
+        }
+
+        // get reward info from the locker
+        IClankerLpLocker.TokenRewardInfo memory tokenRewardInfo =
+            IClankerLpLocker(lpLocker).tokenRewards(clanker);
+
+        // check that the token reward recipient is this address
+        if (tokenRewardInfo.rewardRecipients[0] != address(this)) {
+            revert InvalidFirstFeeRecipient();
+        }
+
+        // check that the token reward admin is the dead address to prevent the
+        // reward recipient from being updated
+        if (tokenRewardInfo.rewardAdmins[0] != address(0x000000000000000000000000000000000000dEaD))
+        {
+            revert InvalidFirstFeeAdmin();
+        }
+
+        // check that this fee recipient is only getting the fees in paired token
+        if (
+            IClankerLpLockerFeeConversion(lpLocker).feePreferences(clanker, 0)
+                != IClankerLpLockerFeeConversion.FeeIn.Paired
+        ) {
+            revert InvalidFirstFeePreference();
+        }
+    }
+
+    // called after a swap has completed
+    function afterSwap(
+        PoolKey calldata,
+        IPoolManager.SwapParams calldata,
+        BalanceDelta delta,
+        bool,
+        bytes calldata
+    ) external onlyApprovedHooks {
+        // claim rewards from the locker
+        if (feeLocker.availableFees(address(this), uniV3InputToken) > 0) {
+            feeLocker.claim(address(this), uniV3InputToken);
+        }
+
+        // if we have no fees to swap, return
+        if (IERC20(uniV3InputToken).balanceOf(address(this)) == 0) {
+            return;
+        }
+
+        // grab amount of token to use for the swap
+        uint256 amountIn = IERC20(uniV3InputToken).balanceOf(address(this));
+
+        // approve the swap router for the amount to spend
+        SafeERC20.forceApprove(IERC20(uniV3InputToken), address(uniV3Router), amountIn);
+
+        // build the swap params
+        ISwapRouterV3.ExactInputSingleParams memory swapBackParams = ISwapRouterV3
+            .ExactInputSingleParams({
+            tokenIn: uniV3InputToken,
+            tokenOut: uniV3OutputToken,
+            fee: uniV3Fee,
+            recipient: buyBackRecipient,
+            amountIn: amountIn,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+
+        // swap the fees for the output token
+        uint256 amountOut = uniV3Router.exactInputSingle(swapBackParams);
+
+        // record the amount swapped
+        emit SwappedBack(uniV3InputToken, uniV3OutputToken, amountIn, amountOut);
+    }
+
+    // Withdraw ETH from the contract
+    function withdrawETH(address recipient) public onlyOwner {
+        payable(recipient).transfer(address(this).balance);
+    }
+
+    // Withdraw ERC20 tokens from the contract
+    function withdrawERC20(address token, address recipient) public onlyOwner {
+        IERC20 token_ = IERC20(token);
+        SafeERC20.safeTransfer(token_, recipient, token_.balanceOf(address(this)));
+    }
+
+    // implements the IClankerHookV2PoolExtension interface
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IClankerHookV2PoolExtension).interfaceId;
+    }
+}

--- a/src/lp-lockers/interfaces/IClankerLpLockerFeeConversion.sol
+++ b/src/lp-lockers/interfaces/IClankerLpLockerFeeConversion.sol
@@ -31,4 +31,6 @@ interface IClankerLpLockerFeeConversion is IClankerLpLockerMultiple {
     );
 
     event InitialFeePreferences(address indexed token, FeeIn[] feePreference);
+
+    function feePreferences(address token, uint256 index) external view returns (FeeIn);
 }

--- a/src/utils/ISwapRouterV3.sol
+++ b/src/utils/ISwapRouterV3.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface ISwapRouterV3 {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+}


### PR DESCRIPTION
This PR contains Clanker's pre-audit `ClankerHookV2` code. This hook upgrade will enable coin deployers to specify custom logic to run after a swap on a pool completes. The custom code needs to be in a contract that implements the interface `IClankerHookV2PoolExtension`. 

To see an example of a pool extension which performs a swap back on an existing uniswap v3 pool, see the `UniV3SwapBack` example.

Note: this is pre audit code that we're still testing. Changes will be made but the general architecture should remain the same.